### PR TITLE
Fix class version for Java 22

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,11 @@ import mill._
 import mill.scalalib._
 import mill.scalalib.publish._
 
-object jdk22 extends JavaModule
+object jdk22 extends JavaModule {
+  def javacOptions = super.javacOptions() ++ Seq(
+    "--release", "22"
+  )
+}
 
 object `is-terminal` extends JavaModule with PublishModule {
   def pomSettings = PomSettings(


### PR DESCRIPTION
Seems we were compiling with Java 23 on the CI, but putting those classes under `META-INF/versions/22/` in the JAR, which was confusing GraalVM 22